### PR TITLE
Added NoisyLatentImage node in  nodes.py

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -871,6 +871,27 @@ class EmptyLatentImage:
         latent = torch.zeros([batch_size, 4, height // 8, width // 8])
         return ({"samples":latent}, )
 
+class NoisyLatentImage:
+    def __init__(self, device="cpu"):
+        self.device = device
+
+    @classmethod
+    def INPUT_TYPES(s):
+        return {"required": { 
+                              "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff}),
+                              "width": ("INT", {"default": 512, "min": 64, "max": MAX_RESOLUTION, "step": 8}),
+                              "height": ("INT", {"default": 512, "min": 64, "max": MAX_RESOLUTION, "step": 8}),
+                              "batch_size": ("INT", {"default": 1, "min": 1, "max": 64})}}
+    RETURN_TYPES = ("LATENT",)
+    FUNCTION = "generate"
+
+    CATEGORY = "latent"
+
+    def generate(self, seed, width, height, batch_size=1):
+        generator = torch.manual_seed(seed)
+        latent = torch.randn([batch_size, 4, height // 8, width // 8], generator=generator, device=self.device)
+        return ({"samples":latent}, )
+
 
 class LatentFromBatch:
     @classmethod


### PR DESCRIPTION
Diffusers library starts with a random noise latent image, instead of an empty latent image. Therefore, adding this node.